### PR TITLE
Change on Refresh Token docs

### DIFF
--- a/content/grant-types/refresh-token.md
+++ b/content/grant-types/refresh-token.md
@@ -111,8 +111,10 @@ This refresh token can then be used to generate a new access token of equal or
 lesser scope:
 
 ```text
-$ curl -u TestClient:TestSecret https://api.mysite.com/token -d 'grant_type=refresh_token&refresh_token=tGzv3JOkF0XG5Qx2TlKWIA'
+$ curl -u TestClient:TestSecret https://api.mysite.com/token -d 'grant_type=refresh_token&refresh_token=tGzv3JOkF0XG5Qx2TlKWIA&client_id=bshaffer&client_secret=37deb3aabb023561291c20cf9aa9669b2c3bbd28'
 ```
+
+Important: remember to insert **refresh_token** grant type to this client in **oauth_clients table**. You can insert as many grant types you wish, space separated.
 
 A successful token request will return a standard access token in JSON format:
 


### PR DESCRIPTION
Refresh Tokens needs client_id and client_secret to be sent to server or else an error is returned ("Client credentials were not found in the headers or body") and this client must have the refresh_token grant type registered in oauth_clients table (each grant type is space separated).
